### PR TITLE
Remove 1 unnecessary stubbing in AutofilledNetworkConfigurationTest.testDoFillSubnetworkItemsEmptyRegion

### DIFF
--- a/src/test/java/com/google/jenkins/plugins/computeengine/AutofilledNetworkConfigurationTest.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/AutofilledNetworkConfigurationTest.java
@@ -94,7 +94,7 @@ public class AutofilledNetworkConfigurationTest {
 
   @Test
   public void testDoFillSubnetworkItemsEmptyRegion() throws IOException {
-    DescriptorImpl descriptor = subnetworkFillDescriptorSetup(ImmutableList.of(SUBNETWORK_NAME));
+    DescriptorImpl descriptor = subnetworkFillDescriptorSetup2(ImmutableList.of(SUBNETWORK_NAME));
     ListBoxModel got =
         descriptor.doFillSubnetworkItems(r.jenkins, "", "", PROJECT_ID, CREDENTIALS_ID);
     Assert.assertEquals(0, got.size());
@@ -157,6 +157,13 @@ public class AutofilledNetworkConfigurationTest {
     ComputeClient computeClient = Mockito.mock(ComputeClient.class);
     Mockito.when(computeClient.listSubnetworks(anyString(), anyString(), anyString()))
         .thenReturn(ImmutableList.copyOf(subnetworks));
+    DescriptorImpl.setComputeClient(computeClient);
+    return new DescriptorImpl();
+  }
+  private DescriptorImpl subnetworkFillDescriptorSetup2(List<String> subnetworkNames) throws IOException {
+    List<Subnetwork> subnetworks = new ArrayList<>();
+    subnetworkNames.forEach(subnet -> subnetworks.add(new Subnetwork().setName(subnet).setSelfLink(subnet)));
+    ComputeClient computeClient = Mockito.mock(ComputeClient.class);
     DescriptorImpl.setComputeClient(computeClient);
     return new DescriptorImpl();
   }


### PR DESCRIPTION
In our analysis of the project, we observed that:
1 unnecessary stubbing which stubbed `listSubnetworks()` in `subnetworkFillDescriptorSetup` is created but is never executed by the test `AutofilledNetworkConfigurationTest.testDoFillSubnetworkItemsEmptyRegion`.

Unnecessary stubbings are stubbed method calls that were never realized during test execution. Mockito recommends to remove unnecessary stubbings (https://www.javadoc.io/doc/org.mockito/mockito-core/latest/org/mockito/exceptions/misusing/UnnecessaryStubbingException.html). We propose below a solution to remove the unnecessary stubbing.